### PR TITLE
Remove deprecated --no-version-check

### DIFF
--- a/resources/streamlink.bat
+++ b/resources/streamlink.bat
@@ -2,4 +2,4 @@
 REM Change the code page for UTF8
 chcp 65001 >NUL
 set PYTHONIOENCODING=cp65001
-"%~dp0\python\python.exe" "%~dp0\streamlink-script.py" --ffmpeg-ffmpeg "%~dp0\ffmpeg\ffmpeg.exe" --rtmp-rtmpdump "%~dp0\rtmpdump\rtmpdump.exe" --config "%~dp0\streamlinkrc" %* --no-version-check
+"%~dp0\python\python.exe" "%~dp0\streamlink-script.py" --ffmpeg-ffmpeg "%~dp0\ffmpeg\ffmpeg.exe" --rtmp-rtmpdump "%~dp0\rtmpdump\rtmpdump.exe" --config "%~dp0\streamlinkrc" %*


### PR DESCRIPTION
This has been removed as of Streamlink 2.0.0:
https://github.com/streamlink/streamlink/releases/tag/2.0.0

Test: manual, attempt download of test video