### PR TITLE
Update for streamlink release 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,37 @@ NB. `sed` must be `gnu-sed`
 
 - Clone this repo and execute the `scripts/makeportable.sh` script.
 
+## Building the zip files under Windows
+
+1. Install [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10). These instructions were done using WSL2 Ubuntu 20.04 LTS with `wsl --install -d Ubuntu-20.04`
+
+2. Update and fetch pre-requisite dependencies:
+```
+sudo apt update
+sudo apt upgrade
+sudo apt install python3-pip zip unzip jq
+```
+
+3. Setup a working dir on a Windows mount, such as `mkdir /mnt/d/scratch` and `cd` into it.
+
+4. Clone this repo and [streamlink/streamlink](https://github.com/streamlink/streamlink) into a subdir called `streamlink` (assigned by default from repo name):
+```
+git clone https://github.com/beardypig/streamlink-portable
+cd streamlink-portable
+git clone https://github.com/streamlink/streamlink
+```
+
+5. Execute script directly as bash: `sudo bash ./scripts/makeportable.sh`
+
+6. Find result inside `dist` subfolder.
 
 ## Changelog
+
+### 2021-07-26
+
+* Fix streamlinkrc -> config rename
+* Call `python3` command directly
+* Add Windows build instructions
 
 ### 2021-01-03
 

--- a/scripts/makeportable.sh
+++ b/scripts/makeportable.sh
@@ -47,10 +47,10 @@ pip install --upgrade -t "${packages_dir}" "iso-639" "iso3166" "setuptools" "req
 
 # create an sdist package to be "installed"
 log "Building streamlink sdist"
-env NO_DEPS=1 python "setup.py" sdist -d "${temp_dir}" > /dev/null
+env NO_DEPS=1 python3 "setup.py" sdist -d "${temp_dir}" > /dev/null
 
 # Work out the streamlink version
-STREAMLINK_VERSION=$(python setup.py --version)
+STREAMLINK_VERSION=$(python3 setup.py --version)
 
 popd > /dev/null
 
@@ -68,7 +68,7 @@ cp "${ROOT_DIR}/resources/streamlink-script.py" "${bundle_dir}/streamlink-script
 cp "${ROOT_DIR}/resources/streamlink.bat" "${bundle_dir}/streamlink.bat"
 cp "${ROOT_DIR}/NOTICE" "${bundle_dir}/NOTICE.txt"
 
-cp -r "${STREAMLINK_CHECKOUT_DIR}/win32/streamlinkrc" "${bundle_dir}/streamlinkrc.template"
+cp -r "${STREAMLINK_CHECKOUT_DIR}/win32/config" "${bundle_dir}/config.template"
 cp -r "${STREAMLINK_CHECKOUT_DIR}/win32/THIRD-PARTY.txt" "${bundle_dir}/THIRD-PARTY.txt"
 
 # download binary assets like ffmpeg and rtmpdump from the streamlink assets repo
@@ -117,8 +117,8 @@ for ((i=$(jq length <<< "${assets_data}") - 1; i >= 0; --i)); do
 done
 
 # remove the rtmpdump and ffmpeg template lines
-sed -i "/^rtmpdump=.*/d" "${bundle_dir}/streamlinkrc.template"
-sed -i "/^ffmpeg-ffmpeg=.*/d" "${bundle_dir}/streamlinkrc.template"
+sed -i "/^rtmpdump=.*/d" "${bundle_dir}/config.template"
+sed -i "/^ffmpeg-ffmpeg=.*/d" "${bundle_dir}/config.template"
 
 pushd "${temp_dir}" > /dev/null
 mkdir -p "${dist_dir}"


### PR DESCRIPTION
Fixes:
- python -> python3 for building on modern systems
- streamlinkrc -> config for new file name
- Added build instructions for WSL2 Ubuntu 20.04 LTS