### PR TITLE
remove rtmpdump argument in batch

### DIFF
--- a/resources/streamlink.bat
+++ b/resources/streamlink.bat
@@ -2,4 +2,4 @@
 REM Change the code page for UTF8
 chcp 65001 >NUL
 set PYTHONIOENCODING=cp65001
-"%~dp0\python\python.exe" "%~dp0\streamlink-script.py" --ffmpeg-ffmpeg "%~dp0\ffmpeg\ffmpeg.exe" --rtmp-rtmpdump "%~dp0\rtmpdump\rtmpdump.exe" --config "%~dp0\config" %*
+"%~dp0\python\python.exe" "%~dp0\streamlink-script.py" --ffmpeg-ffmpeg "%~dp0\ffmpeg\ffmpeg.exe" --config "%~dp0\config" %*


### PR DESCRIPTION
Streamlink dropped support for RTMP https://github.com/streamlink/streamlink/pull/4169