### PR TITLE
Update for streamlink release 4.0+

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,13 @@ jobs:
           path: streamlink
           fetch-depth: 300
 
+      - name: Check out streamlink ${{ steps.streamlink_windows_installer_tag.outputs.VERSION }}
+        uses: actions/checkout@v2
+        with:
+          repository: streamlink/windows-installer
+          path: windows-installer
+          fetch-depth: 300
+
       - name: Grab the latest tags for streamlink
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
         working-directory: streamlink
@@ -39,42 +46,6 @@ jobs:
 
       - name: Install dependencies
         run: pip install -U wheel pip
-
-      - name: Build win32 package (Python 3.6)
-        run: bash ./scripts/makeportable.sh
-        env:
-          STREAMLINK_PYTHON_VERSION: 3.6.8
-          STREAMLINK_PYTHON_ARCH: win32
-
-      - name: Build amd64 package (Python 3.6)
-        run: bash ./scripts/makeportable.sh
-        env:
-          STREAMLINK_PYTHON_VERSION: 3.6.8
-          STREAMLINK_PYTHON_ARCH: amd64
-
-      - name: Build win32 package (Python 3.7)
-        run: bash ./scripts/makeportable.sh
-        env:
-          STREAMLINK_PYTHON_VERSION: 3.7.9
-          STREAMLINK_PYTHON_ARCH: win32
-
-      - name: Build amd64 package (Python 3.7)
-        run: bash ./scripts/makeportable.sh
-        env:
-          STREAMLINK_PYTHON_VERSION: 3.7.9
-          STREAMLINK_PYTHON_ARCH: amd64
-
-      - name: Build win32 package (Python 3.8)
-        run: bash ./scripts/makeportable.sh
-        env:
-          STREAMLINK_PYTHON_VERSION: 3.8.10
-          STREAMLINK_PYTHON_ARCH: win32
-
-      - name: Build amd64 package (Python 3.8)
-        run: bash ./scripts/makeportable.sh
-        env:
-          STREAMLINK_PYTHON_VERSION: 3.8.10
-          STREAMLINK_PYTHON_ARCH: amd64
 
       - name: Build win32 package (Python 3.9)
         run: bash ./scripts/makeportable.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,9 @@ jobs:
         with:
           script: |
             const streamlink_tag_name = await github.repos.listReleases({owner: "streamlink", repo: "streamlink"}).then(releases => releases.data.filter(r => !r.prerelease)[0].tag_name)
+            const streamlink_windows_installer_tag_name = await github.repos.listReleases({owner: "streamlink", repo: "streamlink"}).then(releases => releases.data.filter(r => !r.prerelease)[0].tag_name)
             const portable_tag_name = await github.repos.listReleases({owner: context.repo.owner, repo: context.repo.repo}).then(releases => releases.data.filter(r => !r.prerelease)[0].tag_name)
-            const result = {streamlink: streamlink_tag_name, portable: portable_tag_name};
+            const result = {streamlink: streamlink_tag_name, streamlink_windows_installer: streamlink_windows_installer_tag_name, portable: portable_tag_name};
             console.log(result);
             return result;
 
@@ -29,6 +30,7 @@ jobs:
         id: versions
         run: |
           echo ::set-output name=streamlink_tag::$(echo $json_var | jq -r '.streamlink')
+          echo ::set-output name=streamlink_windows_installer_tag::$(echo $json_var | jq -r '.streamlink_windows_installer')
           echo ::set-output name=streamlink_portable_tag::$(echo $json_var | jq -r '.portable')
         env:
           json_var: ${{ steps.releases.outputs.result }}
@@ -46,6 +48,14 @@ jobs:
           path: streamlink
           ref: ${{ steps.versions.outputs.streamlink_tag }}
 
+      # check out a specific streamlink windows-installer tag
+      - name: Check out streamlink ${{ steps.versions.outputs.streamlink_windows_installer_tag }}
+        uses: actions/checkout@v2
+        with:
+          repository: streamlink/windows-installer
+          path: windows-installer
+          ref: ${{ steps.versions.outputs.streamlink_windows_installer_tag }}
+
       - uses: actions/setup-python@v1
         if: steps.versions.outputs.streamlink_tag != steps.versions.outputs.streamlink_portable_tag
         name: Setup Python
@@ -55,48 +65,6 @@ jobs:
       - name: Install dependencies
         if: steps.versions.outputs.streamlink_tag != steps.versions.outputs.streamlink_portable_tag
         run: pip install -U wheel pip
-
-      - name: Build win32 package (Python 3.6)
-        if: steps.versions.outputs.streamlink_tag != steps.versions.outputs.streamlink_portable_tag
-        run: bash ./scripts/makeportable.sh
-        env:
-          STREAMLINK_PYTHON_VERSION: 3.6.8
-          STREAMLINK_PYTHON_ARCH: win32
-
-      - name: Build amd64 package (Python 3.6)
-        if: steps.versions.outputs.streamlink_tag != steps.versions.outputs.streamlink_portable_tag
-        run: bash ./scripts/makeportable.sh
-        env:
-          STREAMLINK_PYTHON_VERSION: 3.6.8
-          STREAMLINK_PYTHON_ARCH: amd64
-
-      - name: Build win32 package (Python 3.7)
-        if: steps.versions.outputs.streamlink_tag != steps.versions.outputs.streamlink_portable_tag
-        run: bash ./scripts/makeportable.sh
-        env:
-          STREAMLINK_PYTHON_VERSION: 3.7.9
-          STREAMLINK_PYTHON_ARCH: win32
-
-      - name: Build amd64 package (Python 3.7)
-        if: steps.versions.outputs.streamlink_tag != steps.versions.outputs.streamlink_portable_tag
-        run: bash ./scripts/makeportable.sh
-        env:
-          STREAMLINK_PYTHON_VERSION: 3.7.9
-          STREAMLINK_PYTHON_ARCH: amd64
-
-      - name: Build win32 package (Python 3.8)
-        if: steps.versions.outputs.streamlink_tag != steps.versions.outputs.streamlink_portable_tag
-        run: bash ./scripts/makeportable.sh
-        env:
-          STREAMLINK_PYTHON_VERSION: 3.8.10
-          STREAMLINK_PYTHON_ARCH: win32
-
-      - name: Build amd64 package (Python 3.8)
-        if: steps.versions.outputs.streamlink_tag != steps.versions.outputs.streamlink_portable_tag
-        run: bash ./scripts/makeportable.sh
-        env:
-          STREAMLINK_PYTHON_VERSION: 3.8.10
-          STREAMLINK_PYTHON_ARCH: amd64
 
       - name: Build win32 package (Python 3.9)
         if: steps.versions.outputs.streamlink_tag != steps.versions.outputs.streamlink_portable_tag

--- a/README.md
+++ b/README.md
@@ -22,29 +22,48 @@ NB. `sed` must be `gnu-sed`
 
 ## Building the zip files under Windows
 
-1. Install [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10). These instructions were done using WSL2 Ubuntu 20.04 LTS with `wsl --install -d Ubuntu-20.04`
+1. Install [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10). These instructions were done using WSL2 Ubuntu 20.04 LTS with `wsl --install -d Ubuntu-20.04`. A fresh install is assumed, and commands are executed as sudo to avoid additional configuration.
 
 2. Update and fetch pre-requisite dependencies:
 ```
-sudo apt update
-sudo apt upgrade
-sudo apt install python3-pip zip unzip jq
+sudo apt update --yes \
+    && sudo apt upgrade --yes \
+    && sudo apt install --yes python3-pip zip unzip jq python3-testresources
 ```
 
-3. Setup a working dir on a Windows mount, such as `mkdir /mnt/d/scratch` and `cd` into it.
-
-4. Clone this repo and [streamlink/streamlink](https://github.com/streamlink/streamlink) into a subdir called `streamlink` (assigned by default from repo name):
+3. Setup a working dir on a Windows mount. The example provided assumes a D: drive:
 ```
-git clone https://github.com/beardypig/streamlink-portable
-cd streamlink-portable
-git clone https://github.com/streamlink/streamlink
+mkdir -p /mnt/d/scratch \
+    && cd /mnt/d/scratch
 ```
 
-5. Execute script directly as bash: `sudo bash ./scripts/makeportable.sh`
+4. Clone this repo, [streamlink/streamlink](https://github.com/streamlink/streamlink), and the [streamlink/windows-installer](https://github.com/streamlink/windows-installer) into a subdir called `streamlink` (assigned by default from repo name):
+```
+sudo git clone https://github.com/beardypig/streamlink-portable \
+    && cd streamlink-portable \
+    && sudo git clone https://github.com/streamlink/streamlink \
+    && sudo git clone https://github.com/streamlink/windows-installer
+```
+
+5. Execute script directly as bash:
+```
+sudo bash ./scripts/makeportable.sh
+```
 
 6. Find result inside `dist` subfolder.
 
+7. Delete the working dir if it's no longer needed:
+```
+rm -rf /mnt/d/scratch
+```
+
 ## Changelog
+
+### 2022-06-05
+
+* Update Windows build instructions
+* Remove outdated Python versions from workflows (streamlink 4.0+ only supports Python 3.9+)
+* Move from internal win32 config file to new [streamlink/windows-installer](https://github.com/streamlink/windows-installer) repo
 
 ### 2021-10-26
 


### PR DESCRIPTION
Fixes:
- Windows build instruction to include missing dependencies
- Enforced minimum Python 3.9 by removing old workflows
- Updates JSON parsing to account for new windows-installer config

Test: manual, bring up a fresh Ubuntu WSL2 instance and invoke builds
    for win32 and amd64